### PR TITLE
Configurable iam:PassRole roles

### DIFF
--- a/cdk/bin/iot-toolbox.ts
+++ b/cdk/bin/iot-toolbox.ts
@@ -34,6 +34,8 @@ const enableS3Logging = getBoolean(process.env.TOOLBOX_ENABLE_S3_LOGGING || app.
 const enableCloudFrontLogging = getBoolean(process.env.TOOLBOX_ENABLE_CLOUDFRONT_LOGGING || app.node.tryGetContext('enableCloudFrontLogging'))
 const enableVpcLogging = getBoolean(process.env.TOOLBOX_ENABLE_VPC_LOGGING || app.node.tryGetContext('enableVpcLogging'))
 const region = ((process.env.TOOLBOX_REGION || app.node.tryGetContext('region')) as string) || undefined
+const ruleRoleArnsString = ((process.env.TOOLBOX_RULE_ROLE_ARNS || app.node.tryGetContext('ruleRoleArns')) as string) || undefined
+const ruleRoleArns = ruleRoleArnsString ? ruleRoleArnsString.split(',') : []
 
 if (enableCloudFrontWAF && !region) {
   console.error('When enabling WAF for CloudFront, you explicitly need to specify the deployment region for the Toolbox for AWS IoT. Please set the "TOOLBOX_REGION" environment variable or pass the region as CDK context variable "-c region=<region>"')
@@ -64,6 +66,7 @@ const toolboxStack = new IotToolbox(app, 'IotToolbox', {
   enableS3Logging,
   enableVpcLogging,
   enableWAF,
+  ruleRoleArns,
   initialUserEmail,
   cloudfrontWafStack,
   crossRegionReferences: true,

--- a/cdk/lib/deployment.ts
+++ b/cdk/lib/deployment.ts
@@ -22,6 +22,7 @@ export interface IotToolboxProps extends cdk.StackProps {
   enableS3Logging: boolean;
   enableCloudFrontLogging: boolean;
   enableVpcLogging: boolean;
+  ruleRoleArns: string[]
   initialUserEmail?: string;
   cloudfrontWafStack?: CloudfrontWafStack;
 }
@@ -43,7 +44,7 @@ export class IotToolbox extends cdk.Stack {
     const waf = props?.enableWAF ? new WafConstruct(this, 'WAF', { scope: 'REGIONAL' }) : undefined
     this.s3AccessLoggingConstruct = props?.enableS3Logging ? new S3AccessLoggingConstruct(this, 'S3Logs') : undefined
 
-    this.testIotRulesConstruct = new TestIotRulesConstruct(this, 'TestIotRules')
+    this.testIotRulesConstruct = new TestIotRulesConstruct(this, 'TestIotRules', { ruleRoleArns: props?.ruleRoleArns || [] })
     this.recordMessagesConstruct = new RecordMessagesConstruct(this, 'RecordMessages')
     this.replayMessagesConstruct = new ReplayMessagesConstruct(this, 'ReplayMessages', {
       metaDataTable: this.recordMessagesConstruct.metaDataTable,

--- a/cdk/lib/test-iot-rules/infrastructure.ts
+++ b/cdk/lib/test-iot-rules/infrastructure.ts
@@ -7,16 +7,18 @@ import * as cdk from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import { TopicMessage } from './stepfunction/topic-message/infrastructure'
 import { CustomMessage } from './stepfunction/custom-message/infrastructure'
-import { SharedRuleProcessingConstructs } from './stepfunction/shared/infrastructure'
+import { SharedRuleProcessingConstructs, SharedRuleProcessingConstructsProps } from './stepfunction/shared/infrastructure'
+
+interface TestIotRulesConstructProps extends SharedRuleProcessingConstructsProps {}
 
 export class TestIotRulesConstruct extends Construct {
   stepfunctionTopicMessage: cdk.aws_stepfunctions.StateMachine
   stepfunctionCustomMessage: cdk.aws_stepfunctions.StateMachine
 
-  constructor (scope: Construct, id: string) {
+  constructor (scope: Construct, id: string, props: TestIotRulesConstructProps) {
     super(scope, id)
 
-    const sharedConstructs = new SharedRuleProcessingConstructs(this, 'SharedConstructs')
+    const sharedConstructs = new SharedRuleProcessingConstructs(this, 'SharedConstructs', { ...props })
 
     this.stepfunctionTopicMessage = new TopicMessage(this, 'TopicMessage', { ...sharedConstructs }).stepfunction
     this.stepfunctionCustomMessage = new CustomMessage(this, 'CustomMessage', { ...sharedConstructs }).stepfunction

--- a/cdk/lib/test-iot-rules/stepfunction/shared/infrastructure.ts
+++ b/cdk/lib/test-iot-rules/stepfunction/shared/infrastructure.ts
@@ -99,15 +99,6 @@ export class SharedRuleProcessingConstructs extends Construct {
         actions: ['iam:PassRole']
       })
     )
-    // if (props.ruleRoleArns.length > 0) {
-    //   console.log("FUUU")
-    //   this.createRuleLambdaRole.addToPolicy(
-    //     new iam.PolicyStatement({
-    //       resources: props.ruleRoleArns,
-    //       actions: ['iam:PassRole']
-    //     })
-    //   )
-    // }
     this.createRuleLambdaRole.addToPolicy(
       new iam.PolicyStatement({
         resources: ['*'],

--- a/cdk/lib/test-iot-rules/stepfunction/shared/infrastructure.ts
+++ b/cdk/lib/test-iot-rules/stepfunction/shared/infrastructure.ts
@@ -12,6 +12,10 @@ import { ToolboxLambdaFunction } from '../../../common/toolbox-lambda-function'
 import { TOOLBOX_ERROR_TOPIC, TOOLBOX_IOT_RULE_PREFIX } from '../../../constants'
 import path = require('path');
 
+export interface SharedRuleProcessingConstructsProps {
+  ruleRoleArns: string[]
+}
+
 export class SharedRuleProcessingConstructs extends Construct {
   readonly receiveMessageLambda: lambda.Function
   readonly createIngestRuleLambda: lambda.Function
@@ -20,7 +24,7 @@ export class SharedRuleProcessingConstructs extends Construct {
   readonly publishMessageLambdaRole: iam.Role
   readonly createRuleLambdaRole: iam.Role
 
-  constructor (scope: Construct, id: string) {
+  constructor (scope: Construct, id: string, props: SharedRuleProcessingConstructsProps) {
     super(scope, id)
     const receiveMessageRole = new iam.Role(this, 'ReceiveMessageRole', {
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com')
@@ -91,10 +95,19 @@ export class SharedRuleProcessingConstructs extends Construct {
     )
     this.createRuleLambdaRole.addToPolicy(
       new iam.PolicyStatement({
-        resources: [this.publishMessageLambdaRole.roleArn],
+        resources: [this.publishMessageLambdaRole.roleArn].concat(props.ruleRoleArns),
         actions: ['iam:PassRole']
       })
     )
+    // if (props.ruleRoleArns.length > 0) {
+    //   console.log("FUUU")
+    //   this.createRuleLambdaRole.addToPolicy(
+    //     new iam.PolicyStatement({
+    //       resources: props.ruleRoleArns,
+    //       actions: ['iam:PassRole']
+    //     })
+    //   )
+    // }
     this.createRuleLambdaRole.addToPolicy(
       new iam.PolicyStatement({
         resources: ['*'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds support for running IoT rule functions which call other AWS services. For rules to be able to call another AWS service, an IAM role allowing the action must be provided. Because the Toolbox dynamically creates rules based on the user query, it must be able to `iam:PassRole` the required roles to the IoT rules engine. Previously the toolbox didn't have the permission to do so because the permissions scope would have been too big (basically a wildcard PassRole).

With this PR users can now configure through a deployment parameter which roles the toolbox is allowed to pass to rules engine.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
